### PR TITLE
NOJIRA - Using rails routes in specs

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -2,29 +2,21 @@
 
 module AuthHelper
   def sign_in(user)
-    login_endpoint = '/api/v1/sessions'
-
-    post login_endpoint, params: { 'user': { 'email': user.email, 'password': user.password } }
+    post api_v1_sessions_url, params: { 'user': { 'email': user.email, 'password': user.password } }
   end
 
   def sign_out
-    logout_endpoint = '/api/v1/logout'
-
-    delete logout_endpoint
+    delete api_v1_logout_url
   end
 
   def check_authenticated
-    logged_in_endpoint = '/api/v1/logged_in'
-
-    get logged_in_endpoint
+    get api_v1_logged_in_url
   end
 end
 
 module RegistrationHelper
   def register(user)
-    registration_endpoint = '/api/v1/registrations/'
-
-    post registration_endpoint, params: {
+    post api_v1_registrations_url, params: {
       'user': {
         'email': user.email,
         'password': user.password,

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe 'Articles', type: :request do
   let(:first_article) { create(:article) }
   let(:discarded_article) { create(:article, discarded_at: DateTime.now) }
-  let(:articles_endpoint) { '/api/v1/articles/' }
 
   context 'authenticated users' do
     before(:each) do
@@ -14,7 +13,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be able to delete articles' do
-      delete "#{articles_endpoint}#{first_article.id}"
+      delete "#{api_v1_articles_url}/#{first_article.id}"
       response_body = JSON.parse(response.body)
 
       expect(response_body.count).to eq 2
@@ -23,7 +22,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be unable to create articles for other users' do
-      post articles_endpoint, params: { article: { user_id: discarded_article.user.id } }
+      post api_v1_articles_url, params: { article: { user_id: discarded_article.user.id } }
       response_body = JSON.parse(response.body)
 
       expect(response_body.count).to eq 1
@@ -31,7 +30,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be able to edit articles' do
-      patch "#{articles_endpoint}#{first_article.id}", params: { article: { title: 'Some New Title' } }
+      patch "#{api_v1_articles_url}/#{first_article.id}", params: { article: { title: 'Some New Title' } }
       response_body = JSON.parse(response.body)
 
       expect(response_body['data']['id']).to eq first_article.id.to_s
@@ -39,7 +38,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be able to recover articles' do
-      post "#{articles_endpoint}#{discarded_article.id}/recover"
+      post "#{api_v1_articles_url}/#{discarded_article.id}/recover"
       response_body = JSON.parse(response.body)
 
       expect(response_body['data']['id']).to eq discarded_article.id.to_s
@@ -50,7 +49,7 @@ RSpec.describe 'Articles', type: :request do
 
   context 'unauthenticated users' do
     it 'should not be able to delete articles' do
-      delete "#{articles_endpoint}#{first_article.id}"
+      delete "#{api_v1_articles_url}/#{first_article.id}"
       response_body = JSON.parse(response.body)
       # { 'error': 'Access Denied' }
       expect(response_body.count).to eq 1
@@ -58,7 +57,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should not be able to edit articles' do
-      patch "#{articles_endpoint}#{first_article.id}", params: { title: 'Some New Title' }
+      patch "#{api_v1_articles_url}/#{first_article.id}", params: { title: 'Some New Title' }
       response_body = JSON.parse(response.body)
 
       expect(response_body.count).to eq 1
@@ -66,7 +65,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should not be able to recover articles' do
-      post "#{articles_endpoint}#{discarded_article.id}/recover"
+      post "#{api_v1_articles_url}/#{discarded_article.id}/recover"
       response_body = JSON.parse(response.body)
 
       expect(response_body.count).to eq 1
@@ -82,14 +81,14 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be able to view all articles' do
-      get articles_endpoint
+      get api_v1_articles_url
       response_body = JSON.parse(response.body)
 
       expect(response_body['data'].count).to eq Article.count
     end
 
     it 'should be able to view specific articles' do
-      get "#{articles_endpoint}#{Article.first.id}"
+      get "#{api_v1_articles_url}/#{Article.first.id}"
       response_body = JSON.parse(response.body)
 
       expect(response_body.count).to eq 1


### PR DESCRIPTION
- Was previously using hardcoded endpoints for request specs (`/api/v1/articles`).
- Now replaced with rails URL helpers (`api_v1_articles_url`).