### PR TITLE
ATH-1329 - Automatically Archive Blog Posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,4 @@ gem 'fast_jsonapi'
 gem 'rack-cors'
 gem 'react-rails'
 gem 'rspec-rails'
+gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chronic (0.10.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
     crass (1.0.6)
@@ -237,6 +238,8 @@ GEM
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -271,6 +274,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
+  whenever
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ show_specs: ## show specs for rails application
 
 annotate_models: ## annotate model schemas
 	annotate --models
+
+recreate_db: ## reset database and reload current schema
+	rake db:reset db:migrate

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -11,7 +11,7 @@ module Api
       # GET /articles.json
       def index
         archived = request.query_parameters['archived'] ? 1 : 0
-        articles = Article.kept.where('archived = ?', archived)
+        articles = Article.order(updated_at: :desc).kept.where(archived: archived)
 
         render json: create_article_serializer(articles)
       end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -7,9 +7,11 @@ module Api
       before_action :authenticate, only: %i[create update destroy recover]
 
       # GET /articles
+      # GET /articles/?archived=true
       # GET /articles.json
       def index
-        articles = Article.kept
+        archived = request.query_parameters['archived'] ? 1 : 0
+        articles = Article.kept.where('archived = ?', archived)
 
         render json: create_article_serializer(articles)
       end

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -12,5 +12,5 @@
 #
 class ArticleSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :title, :content, :user_id, :created_at, :updated_at, :discarded_at
+  attributes :title, :content, :user_id, :created_at, :updated_at, :discarded_at, :archived
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,9 @@
+# Use this file to easily define all of your cron jobs.
+
+set :output, { standard: 'log/cron.log', error: 'log/error.log' }
+
+every 2.hours do
+  rake 'archive_articles', environment: 'development'
+end
+
+# Learn more: http://github.com/javan/whenever

--- a/db/migrate/20200622095905_add_archived_to_articles.rb
+++ b/db/migrate/20200622095905_add_archived_to_articles.rb
@@ -1,0 +1,5 @@
+class AddArchivedToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :archived, :boolean
+  end
+end

--- a/db/migrate/20200622095905_add_archived_to_articles.rb
+++ b/db/migrate/20200622095905_add_archived_to_articles.rb
@@ -1,5 +1,5 @@
 class AddArchivedToArticles < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles, :archived, :boolean
+    add_column :articles, :archived, :boolean, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_19_130145) do
+ActiveRecord::Schema.define(version: 2020_06_22_095905) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_06_19_130145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
+    t.boolean "archived"
     t.index ["discarded_at"], name: "index_articles_on_discarded_at"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2020_06_22_095905) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "discarded_at"
-    t.boolean "archived"
+    t.boolean "archived", default: false
     t.index ["discarded_at"], name: "index_articles_on_discarded_at"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end

--- a/lib/tasks/archive_articles.rake
+++ b/lib/tasks/archive_articles.rake
@@ -1,0 +1,9 @@
+desc 'Archive articles that have not been updated in 7 days.'
+
+task archive_articles: :environment do
+  articles_to_archive = Article.order(:updated_at).kept.where('updated_at <= ?', Time.now - 7.days)
+
+  articles_to_archive.each do |article|
+    puts article
+  end
+end

--- a/lib/tasks/archive_articles.rake
+++ b/lib/tasks/archive_articles.rake
@@ -4,6 +4,7 @@ task archive_articles: :environment do
   articles_to_archive = Article.order(:updated_at).kept.where('updated_at <= ?', Time.now - 7.days)
 
   articles_to_archive.each do |article|
-    puts article
+    article.archived = true
+    article.save
   end
 end

--- a/lib/tasks/archive_articles.rake
+++ b/lib/tasks/archive_articles.rake
@@ -1,9 +1,13 @@
 desc 'Archive articles that have not been updated in 7 days.'
 
 task archive_articles: :environment do
+  puts "\nExecuting task at #{Time.now}."
+
   articles_to_archive = Article.order(:updated_at).kept.where('updated_at <= ?', Time.now - 7.days)
 
   articles_to_archive.each do |article|
+    puts "Archiving Article: { #{article.id}: #{article.title} }"
+
     article.archived = true
     article.save
   end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Articles', type: :request do
     end
 
     it 'should be able to view archived articles' do
-      get articles_endpoint, params: { archived: true }
+      get api_v1_articles_url, params: { archived: true }
       response_body = JSON.parse(response.body)
 
       expect(response_body['data'].count).to eq 1

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -79,13 +79,21 @@ RSpec.describe 'Articles', type: :request do
       # need some articles in the test database for retrieving
       create(:article).save
       create(:article).save
+      create(:article, archived: true).save
     end
 
     it 'should be able to view all articles' do
       get articles_endpoint
       response_body = JSON.parse(response.body)
 
-      expect(response_body['data'].count).to eq Article.count
+      expect(response_body['data'].count).to eq 2
+    end
+
+    it 'should be able to view archived articles' do
+      get articles_endpoint, params: { archived: true }
+      response_body = JSON.parse(response.body)
+
+      expect(response_body['data'].count).to eq 1
     end
 
     it 'should be able to view specific articles' do


### PR DESCRIPTION
- Articles older than a week are archived automatically using a custom rake task && `whenever` gem.
- Currently executes every 2 hours.
- Added a query param for fetching archived articles: `/api/v1/articles&archived=true`

![image](https://user-images.githubusercontent.com/66415822/85308010-97a68700-b4a8-11ea-98f3-ba6d187a80a1.png)
